### PR TITLE
W-23692110: Fix ESM wrapper benchmark fixture

### DIFF
--- a/.github/actions/python/action.yml
+++ b/.github/actions/python/action.yml
@@ -32,7 +32,11 @@ runs:
   using: composite
   steps:
     - name: Install Python build dependencies
-      run: python3 -m pip install ${{ inputs.break-system-packages == 'true' && '--break-system-packages' || '' }} --upgrade setuptools wheel
+      # --ignore-installed: on macOS runners, Homebrew's own setuptools/wheel have no
+      # pip RECORD file, so a plain --upgrade fails trying to uninstall them first
+      # (pip error "uninstall-no-record-file"). --ignore-installed installs pip's
+      # copy on top without needing to remove the untracked brew one.
+      run: python3 -m pip install ${{ inputs.break-system-packages == 'true' && '--break-system-packages' || '' }} --upgrade --ignore-installed setuptools wheel
       shell: bash
 
     - name: Create Native Lib Python Wheel

--- a/benchmarks/runners/node/wrapper.test.mjs
+++ b/benchmarks/runners/node/wrapper.test.mjs
@@ -41,6 +41,7 @@ test("DW_BENCH_NODE_PACKAGE set to valid package dir loads", async () => {
   const packageDir = makeTempDir();
   const distDir = join(packageDir, "dist");
   mkdirSync(distDir, { recursive: true });
+  writeFileSync(join(packageDir, "package.json"), '{"type":"module"}');
   writeFileSync(join(distDir, "index.js"), "export function run() { return null; }");
 
   process.env.DW_BENCH_NODE_PACKAGE = packageDir;


### PR DESCRIPTION
## Summary
- declare the temporary benchmark wrapper fixture as an ESM package
- allow the ESM dist/index.js fixture to load under Node 18

## Verification
- ./gradlew native-lib:benchmarkJsUnitTest
- ./gradlew build

The failure was hidden in GitHub Actions because the foundation build passes -PskipNodeTests=true, which disables benchmarkJsUnitTest.