### PR TITLE
@W-23751646: Harden Python TCK coverage accounting

### DIFF
--- a/native-lib/.gitignore
+++ b/native-lib/.gitignore
@@ -2,5 +2,6 @@ python/src/dataweave/native/
 python/src/dataweave_native.egg-info/
 python/dist/
 python/build/
+python/.coverage
 
 node_modules/

--- a/native-lib/python/tests/conftest.py
+++ b/native-lib/python/tests/conftest.py
@@ -13,7 +13,12 @@ import dataweave
 
 def _tck_discovery():
     from tck.case_loader import discover_cases
-    from tck.ignore_list import EXCLUDED_CASES, STRUCTURAL_MODULE_CASES, validate_exclusions
+    from tck.ignore_list import (
+        EXCLUDED_CASES,
+        STRUCTURAL_MODULE_CASES,
+        validate_exclusions,
+        validate_structural_module_cases,
+    )
 
     suites_dir = Path(__file__).resolve().parents[2] / "node" / "tests" / "tck" / "suites"
     discovery = discover_cases(suites_dir)
@@ -23,13 +28,19 @@ def _tck_discovery():
         for scenario in discovered_case.scenarios
     ]
     errors = validate_exclusions(EXCLUDED_CASES, scenarios)
+    errors.extend(
+        validate_structural_module_cases(
+            STRUCTURAL_MODULE_CASES,
+            discovery.structural_module_case_identifiers,
+        )
+    )
     if errors:
-        raise pytest.UsageError("Invalid active TCK exclusions: " + "; ".join(errors))
+        raise pytest.UsageError("Invalid TCK policy: " + "; ".join(errors))
     exclusions = [
         scenario for scenario in scenarios
         if scenario.identifier.rsplit(":", 1)[0] in EXCLUDED_CASES
     ]
-    structural_modules = set(discovery.structural_case_identifiers) & STRUCTURAL_MODULE_CASES
+    structural_modules = set(discovery.structural_module_case_identifiers)
     return discovery, scenarios, exclusions, structural_modules
 
 
@@ -38,10 +49,27 @@ def pytest_configure(config):
         config._tck_discovery = _tck_discovery()
 
 
+def pytest_collection_finish(session):
+    config = session.config
+    if not hasattr(config, "_tck_discovery"):
+        return
+    marker = "::test_tck_scenario["
+    config._tck_selected_identifiers = {
+        item.nodeid.split(marker, 1)[1].rsplit("]", 1)[0]
+        for item in session.items
+        if marker in item.nodeid
+    }
+
+
 def pytest_report_header(config):
     if not hasattr(config, "_tck_discovery"):
         return None
     discovery, scenarios, exclusions, structural_modules = config._tck_discovery
+    selected_identifiers = getattr(
+        config,
+        "_tck_selected_identifiers",
+        {scenario.identifier for scenario in scenarios},
+    )
     categories = {}
     from tck.ignore_list import exclusion_for
 
@@ -62,13 +90,12 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if not hasattr(config, "_tck_discovery"):
         return
     discovery, scenarios, exclusions, structural_modules = config._tck_discovery
-    reports = [
-        report
-        for reports in terminalreporter.stats.values()
-        for report in reports
-        if getattr(report, "when", None) == "call"
-        and "::test_tck_scenario[" in report.nodeid
-    ]
+    selected_identifiers = getattr(
+        config,
+        "_tck_selected_identifiers",
+        {scenario.identifier for scenario in scenarios},
+    )
+    reports = _tck_reports(terminalreporter)
     totals = {
         outcome: sum(
             report.outcome == outcome
@@ -77,15 +104,57 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         )
         for outcome in ("passed", "failed", "skipped")
     }
-    xfailed = sum(bool(getattr(report, "wasxfail", None)) for report in reports)
+    xfailed = sum(
+        report.outcome == "skipped" and bool(getattr(report, "wasxfail", None))
+        for report in reports
+    )
     executed = totals["passed"] + totals["failed"]
+    accounted = executed + totals["skipped"] + xfailed
+    unaccounted = len(selected_identifiers) - accounted
     terminalreporter.write_line(
         "TCK totals: "
-        f"selected={len(scenarios)}, structural-skips={discovery.structural_skips}, "
+        f"selected={len(selected_identifiers)}, structural-skips={discovery.structural_skips}, "
         f"structural-module-cases={len(structural_modules)}, "
         f"executed={executed}, active-exclusions={totals['skipped']}, passed={totals['passed']}, "
-        f"failed={totals['failed']}, xfail={xfailed}"
+        f"failed={totals['failed']}, xfail={xfailed}, accounted={accounted}, "
+        f"unaccounted={unaccounted}"
     )
+
+
+def pytest_sessionfinish(session, exitstatus):
+    config = session.config
+    if (
+        exitstatus != pytest.ExitCode.OK
+        or not hasattr(config, "_tck_discovery")
+        or config.option.keyword
+    ):
+        return
+    _discovery, scenarios, _exclusions, _structural_modules = config._tck_discovery
+    terminalreporter = config.pluginmanager.get_plugin("terminalreporter")
+    if terminalreporter is None:
+        return
+    expected = getattr(
+        config,
+        "_tck_selected_identifiers",
+        {scenario.identifier for scenario in scenarios},
+    )
+    reported = [_tck_report_identifier(report) for report in _tck_reports(terminalreporter)]
+    if len(reported) != len(set(reported)) or set(reported) != expected:
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+
+def _tck_reports(terminalreporter):
+    return [
+        report
+        for reports in terminalreporter.stats.values()
+        for report in reports
+        if getattr(report, "when", None) == "call"
+        and "::test_tck_scenario[" in report.nodeid
+    ]
+
+
+def _tck_report_identifier(report):
+    return report.nodeid.split("::test_tck_scenario[", 1)[1].rsplit("]", 1)[0]
 
 
 @pytest.fixture(autouse=True)

--- a/native-lib/python/tests/tck/case_loader.py
+++ b/native-lib/python/tests/tck/case_loader.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
+import re
 from typing import Dict, List, Optional
 
 from dataweave import InputValue
@@ -18,6 +19,11 @@ EXTENSION_TO_MIME = {
     "urlencoded": "application/x-www-form-urlencoded",
     "xml": "application/xml",
 }
+
+INPUT_PATTERN = re.compile(r"^in[0-9]+\.[a-zA-Z]+$")
+OUTPUT_PATTERN = re.compile(r"^out\.[a-zA-Z]+$")
+INPUT_CONFIG_PATTERN = re.compile(r"^in[0-9]+-config\.properties$")
+OUTPUT_CONFIG_PATTERN = re.compile(r"^out[0-9]*-config\.properties$")
 
 
 @dataclass(frozen=True)
@@ -41,6 +47,7 @@ class Discovery:
     cases: List[DiscoveredCase]
     structural_skips: int
     structural_case_identifiers: List[str]
+    structural_module_case_identifiers: List[str]
 
 
 def extension_of(name: str) -> str:
@@ -51,8 +58,14 @@ def discover_cases(suites_dir: Path) -> Discovery:
     cases: List[DiscoveredCase] = []
     structural_skips = 0
     structural_case_identifiers: List[str] = []
+    structural_module_case_identifiers: List[str] = []
     if not suites_dir.exists():
-        return Discovery(cases, structural_skips, structural_case_identifiers)
+        return Discovery(
+            cases,
+            structural_skips,
+            structural_case_identifiers,
+            structural_module_case_identifiers,
+        )
 
     for suite_dir in sorted(path for path in suites_dir.iterdir() if path.is_dir()):
         for case_dir in sorted(path for path in suite_dir.iterdir() if path.is_dir()):
@@ -63,10 +76,29 @@ def discover_cases(suites_dir: Path) -> Discovery:
             scenarios = _load_case(suite_dir.name, case_dir)
             if scenarios is None:
                 structural_skips += 1
-                structural_case_identifiers.append(f"{suite_dir.name}/{case_dir.name}")
+                identifier = f"{suite_dir.name}/{case_dir.name}"
+                structural_case_identifiers.append(identifier)
+                if _has_adjacent_dwl_module(case_dir):
+                    structural_module_case_identifiers.append(identifier)
             else:
                 cases.append(DiscoveredCase(f"{suite_dir.name}/{case_dir.name}", scenarios))
-    return Discovery(cases, structural_skips, structural_case_identifiers)
+    return Discovery(
+        cases,
+        structural_skips,
+        structural_case_identifiers,
+        structural_module_case_identifiers,
+    )
+
+
+def _has_adjacent_dwl_module(case_dir: Path) -> bool:
+    return any(
+        path.is_file()
+        and extension_of(path.name) == "dwl"
+        and not INPUT_PATTERN.fullmatch(path.name)
+        and not OUTPUT_PATTERN.fullmatch(path.name)
+        and path.name != "transform.dwl"
+        for path in case_dir.iterdir()
+    )
 
 
 def _load_case(suite_name: str, case_dir: Path) -> Optional[List[TckScenario]]:
@@ -75,7 +107,8 @@ def _load_case(suite_name: str, case_dir: Path) -> Optional[List[TckScenario]]:
     if case_name.endswith("_wip") or case_name.endswith("wip"):
         return None
     if "config.properties" in files or any(
-        name.startswith(("in", "out")) and name.endswith("-config.properties") for name in files
+        INPUT_CONFIG_PATTERN.fullmatch(name) or OUTPUT_CONFIG_PATTERN.fullmatch(name)
+        for name in files
     ):
         return None
     if any(extension_of(name) == "groovy" for name in files):
@@ -83,19 +116,25 @@ def _load_case(suite_name: str, case_dir: Path) -> Optional[List[TckScenario]]:
 
     transforms = [
         path for name, path in files.items()
-        if extension_of(name) == "dwl" and not name.startswith("in") and not name.startswith("out")
+        if extension_of(name) == "dwl"
+        and not INPUT_PATTERN.fullmatch(name)
+        and not OUTPUT_PATTERN.fullmatch(name)
     ]
     if len(transforms) != 1 or "transform.dwl" not in files:
         return None
 
     input_paths = sorted(
-        (path for name, path in files.items() if name.startswith("in") and name[2:].split(".", 1)[0].isdigit()),
+        (path for name, path in files.items() if INPUT_PATTERN.fullmatch(name)),
         key=lambda path: path.name,
     )
     if any(extension_of(path.name) not in EXTENSION_TO_MIME for path in input_paths):
         return None
     output_paths = sorted(
-        (path for name, path in files.items() if name.startswith("out.") and extension_of(name) in EXTENSION_TO_MIME),
+        (
+            path
+            for name, path in files.items()
+            if OUTPUT_PATTERN.fullmatch(name) and extension_of(name) in EXTENSION_TO_MIME
+        ),
         key=lambda path: path.name,
     )
     if not output_paths:

--- a/native-lib/python/tests/tck/compare.py
+++ b/native-lib/python/tests/tck/compare.py
@@ -27,6 +27,8 @@ def compare_output(
     try:
         actual_text = actual.decode(encoding)
         expected_text = expected.decode(encoding)
+    except LookupError as error:
+        return CompareResult(False, f"unknown output charset {encoding}: {error}")
     except UnicodeDecodeError as error:
         return CompareResult(False, f"cannot decode output as {encoding}: {error}")
     if extension == "json":

--- a/native-lib/python/tests/tck/ignore_list.py
+++ b/native-lib/python/tests/tck/ignore_list.py
@@ -33,6 +33,10 @@ STRUCTURAL_MODULE_CASES = frozenset(
         "runtime/location-out.json",
         "runtime/locationString-out.json",
         "runtime/logwith_function-out.json",
+        "runtime/read-function-by-id-out.json",
+        "runtime/read-function-out.json",
+        "runtime/runtime_evalUrl-out.json",
+        "runtime/runtime_runUrl-out.json",
         "runtime/type_selector_materialize-out.json",
         "runtime/weave_multiple_namespace-out.dwl",
     )
@@ -233,16 +237,6 @@ EXCLUDED_CASES: Dict[str, Exclusion] = {
         UNAVAILABLE_CLASSPATH_TEST_RESOURCE,
         "readUrl cannot find classpath://dw-binary/in0.bin",
     ),
-    "runtime/read-function-by-id-out.json": _exclusion(
-        "runtime/read-function-by-id-out.json",
-        UNAVAILABLE_CLASSPATH_TEST_RESOURCE,
-        "readUrl cannot find classpath://read-function-by-id/include.dwl",
-    ),
-    "runtime/read-function-out.json": _exclusion(
-        "runtime/read-function-out.json",
-        UNAVAILABLE_CLASSPATH_TEST_RESOURCE,
-        "readUrl cannot find classpath://read-function/include.dwl",
-    ),
     "runtime/read_lines-out.json": _exclusion(
         "runtime/read_lines-out.json",
         UNAVAILABLE_CLASSPATH_TEST_RESOURCE,
@@ -281,6 +275,24 @@ def validate_exclusions(
         for identifier in entries:
             if identifier not in discovered:
                 errors.append(f"{identifier}: not a discovered runnable case")
+    return errors
+
+
+def validate_structural_module_cases(
+    entries: Iterable[str], structural_case_identifiers: Iterable[str]
+) -> List[str]:
+    registry = set(entries)
+    structural_skips = set(structural_case_identifiers)
+    errors = [
+        f"{identifier}: not a structural skip"
+        for identifier in sorted(registry)
+        if identifier not in structural_skips
+    ]
+    errors.extend(
+        f"{identifier}: structural module case is not registered"
+        for identifier in sorted(structural_skips)
+        if identifier not in registry
+    )
     return errors
 
 

--- a/native-lib/python/tests/tck/test_conformance.py
+++ b/native-lib/python/tests/tck/test_conformance.py
@@ -18,9 +18,11 @@ from compare import compare_output
 from ignore_list import (
     EXCLUDED_CASES,
     Exclusion,
+    STRUCTURAL_MODULE_CASES,
     UNSUPPORTED_DW_MODULE_RESOLUTION,
     exclusion_for,
     validate_exclusions,
+    validate_structural_module_cases,
 )
 from conftest import pytest_terminal_summary
 
@@ -117,6 +119,35 @@ def test_tck_summary_counts_xfails_as_visible_expected_mismatches():
 
     assert "active-exclusions=0" in output[-1]
     assert "xfail=1" in output[-1]
+    assert "accounted=1" in output[-1]
+
+
+def test_tck_summary_counts_strict_xpass_once_as_a_failure():
+    output = []
+    terminalreporter = SimpleNamespace(
+        stats={
+            "failed": [
+                SimpleNamespace(
+                    when="call",
+                    nodeid="tests/tck/test_conformance.py::test_tck_scenario[runtime/repaired:out.json]",
+                    outcome="failed",
+                    wasxfail="accepted mismatch",
+                )
+            ]
+        },
+        write_line=output.append,
+    )
+    config = SimpleNamespace(
+        _tck_discovery=(DISCOVERY, SCENARIOS, [], set()),
+        _tck_selected_identifiers={"runtime/repaired:out.json"},
+    )
+
+    pytest_terminal_summary(terminalreporter, 0, config)
+
+    assert "failed=1" in output[-1]
+    assert "xfail=0" in output[-1]
+    assert "accounted=1" in output[-1]
+    assert "unaccounted=0" in output[-1]
 
 
 @pytest.mark.parametrize("scenario", tck_params())
@@ -243,6 +274,49 @@ def test_discover_cases_loads_transform_input_output_and_scenarios(tmp_path: Pat
     assert scenarios[0].expected == b'{"answer": 42}'
 
 
+def test_discover_cases_ignores_files_that_only_resemble_inputs_and_outputs(tmp_path: Path):
+    """Catches broad prefix matching that changes the runnable TCK inventory."""
+    write_case(
+        tmp_path,
+        "exact-file-patterns-out.json",
+        {
+            "transform.dwl": "%dw 2.0\noutput application/json\n---\nin0",
+            "in0.json": '{"answer": 42}',
+            "input1.json": '{"wrong": true}',
+            "out.json": '{"answer": 42}',
+            "output.json": '{"wrong": true}',
+        },
+    )
+
+    discovery = discover_cases(tmp_path)
+
+    assert len(discovery.cases) == 1
+    scenarios = discovery.cases[0].scenarios
+    assert [scenario.identifier for scenario in scenarios] == [
+        "runtime/exact-file-patterns-out.json:out.json"
+    ]
+    assert set(scenarios[0].inputs) == {"in0"}
+
+
+def test_discover_cases_structurally_skips_adjacent_dwl_modules(tmp_path: Path):
+    """Catches discovery that mistakes a multi-DWL case for one runnable transform."""
+    write_case(
+        tmp_path,
+        "local-module-out.json",
+        {
+            "transform.dwl": "%dw 2.0\noutput application/json\n---\ninclude::value",
+            "include.dwl": "%dw 2.0\nvar value = 42",
+            "out.json": "42",
+        },
+    )
+
+    discovery = discover_cases(tmp_path)
+
+    assert discovery.cases == []
+    assert discovery.structural_skips == 1
+    assert discovery.structural_case_identifiers == ["runtime/local-module-out.json"]
+
+
 @pytest.mark.parametrize(
     ("extension", "actual", "expected"),
     [
@@ -298,6 +372,25 @@ def test_compare_output_rejects_different_namespace_prefixes():
     )
 
     assert not result.match
+
+
+def test_compare_output_preserves_interleaved_xml_child_order():
+    """Catches XML normalization that groups children by tag and loses ordering."""
+    result = compare_output(
+        "xml",
+        b"<root><a>1</a><b>2</b><a>3</a></root>",
+        b"<root><a>1</a><a>3</a><b>2</b></root>",
+    )
+
+    assert not result.match
+
+
+def test_compare_output_reports_unknown_charset():
+    """Catches unsupported sidecar encodings escaping as uncaught lookup errors."""
+    result = compare_output("json", b"{}", b"{}", "not-a-real-charset")
+
+    assert not result.match
+    assert "unknown output charset" in result.detail
 
 
 def test_exclusion_registry_requires_category_and_reason():
@@ -362,7 +455,7 @@ def test_only_declared_case_identifiers_are_excluded():
     exclusion = exclusion_for("runtime/import-lib-out.json")
     assert exclusion.case_identifier == "runtime/import-lib-out.json"
     assert exclusion.category == "unsupported-dw-module-resolution"
-    assert len(EXCLUDED_CASES) == 39
+    assert len(EXCLUDED_CASES) == 37
 
 
 def test_exclusion_registry_uses_the_inventory_categories():
@@ -372,7 +465,7 @@ def test_exclusion_registry_uses_the_inventory_categories():
         categories[exclusion.category] = categories.get(exclusion.category, 0) + 1
 
     assert categories == {
-        "unavailable-classpath-test-resource": 4,
+        "unavailable-classpath-test-resource": 2,
         "unavailable-java-module": 11,
         "unsupported-dw-module-resolution": 24,
     }
@@ -408,6 +501,33 @@ def test_exclusion_registry_rejects_unreachable_active_entries():
     assert errors == ["runtime/not-discovered: not a discovered runnable case"]
 
 
+def test_structural_module_registry_rejects_entries_that_are_not_structural_skips():
+    """Catches stale structural-module entries after a case becomes runnable."""
+    errors = validate_structural_module_cases(
+        {"runtime/local-module", "runtime/not-structural"},
+        ["runtime/local-module"],
+    )
+
+    assert errors == ["runtime/not-structural: not a structural skip"]
+
+
+def test_structural_module_registry_rejects_unregistered_structural_modules():
+    """Catches adjacent-module cases omitted from the audited inventory."""
+    errors = validate_structural_module_cases(
+        {"runtime/registered"},
+        ["runtime/registered", "runtime/missing"],
+    )
+
+    assert errors == ["runtime/missing: structural module case is not registered"]
+
+
+def test_structural_module_registry_matches_staged_structural_cases():
+    assert validate_structural_module_cases(
+        STRUCTURAL_MODULE_CASES,
+        DISCOVERY.structural_module_case_identifiers,
+    ) == []
+
+
 def test_tck_summary_ignores_collection_nodes():
     """Catches pytest collection nodes being counted as test reports."""
     output = []
@@ -439,6 +559,100 @@ def test_tck_summary_ignores_collection_nodes():
     pytest_terminal_summary(terminalreporter, 0, config)
 
     assert output[-1] == (
-        "TCK totals: selected=731, structural-skips=191, structural-module-cases=0, executed=2, "
-        "active-exclusions=1, passed=1, failed=1, xfail=0"
+        "TCK totals: selected=729, structural-skips=193, structural-module-cases=0, executed=2, "
+        "active-exclusions=1, passed=1, failed=1, xfail=0, accounted=3, unaccounted=726"
     )
+
+
+def test_tck_session_fails_when_a_complete_run_leaves_scenarios_unaccounted():
+    terminalreporter = SimpleNamespace(stats={"passed": []})
+    config = SimpleNamespace(
+        _tck_discovery=(DISCOVERY, SCENARIOS, [], set()),
+        option=SimpleNamespace(keyword=""),
+        pluginmanager=SimpleNamespace(get_plugin=lambda name: terminalreporter),
+    )
+    session = SimpleNamespace(config=config, exitstatus=0)
+
+    from conftest import pytest_sessionfinish
+
+    pytest_sessionfinish(session, 0)
+
+    assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
+
+
+def test_tck_session_fails_when_duplicate_report_hides_missing_scenario():
+    first = SCENARIOS[0].identifier
+    reports = [
+        SimpleNamespace(
+            when="call",
+            nodeid=f"tests/tck/test_conformance.py::test_tck_scenario[{first}]",
+            outcome="passed",
+        )
+        for _scenario in SCENARIOS
+    ]
+    terminalreporter = SimpleNamespace(stats={"passed": reports})
+    config = SimpleNamespace(
+        _tck_discovery=(DISCOVERY, SCENARIOS, [], set()),
+        _tck_selected_identifiers={scenario.identifier for scenario in SCENARIOS},
+        option=SimpleNamespace(keyword=""),
+        pluginmanager=SimpleNamespace(get_plugin=lambda name: terminalreporter),
+    )
+    session = SimpleNamespace(config=config, exitstatus=0)
+
+    from conftest import pytest_sessionfinish
+
+    pytest_sessionfinish(session, 0)
+
+    assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
+
+
+def test_tck_session_allows_intentionally_filtered_runs():
+    terminalreporter = SimpleNamespace(stats={"passed": []})
+    config = SimpleNamespace(
+        _tck_discovery=(DISCOVERY, SCENARIOS, [], set()),
+        option=SimpleNamespace(keyword="one-scenario"),
+        pluginmanager=SimpleNamespace(get_plugin=lambda name: terminalreporter),
+    )
+    session = SimpleNamespace(config=config, exitstatus=0)
+
+    from conftest import pytest_sessionfinish
+
+    pytest_sessionfinish(session, 0)
+
+    assert session.exitstatus == 0
+
+
+def test_tck_summary_uses_collected_scenario_selection():
+    output = []
+    terminalreporter = SimpleNamespace(stats={}, write_line=output.append)
+    config = SimpleNamespace(
+        _tck_discovery=(DISCOVERY, SCENARIOS, [], set()),
+        _tck_selected_identifiers=set(),
+    )
+
+    pytest_terminal_summary(terminalreporter, 0, config)
+
+    assert "selected=0" in output[-1]
+    assert "unaccounted=0" in output[-1]
+
+
+def test_tck_collection_records_only_selected_scenarios():
+    from conftest import pytest_collection_finish
+
+    selected = SCENARIOS[0].identifier
+    config = SimpleNamespace(_tck_discovery=(DISCOVERY, SCENARIOS, [], set()))
+    session = SimpleNamespace(
+        config=config,
+        items=[
+            SimpleNamespace(
+                nodeid=f"tests/tck/test_conformance.py::test_tck_scenario[{selected}]"
+            ),
+            SimpleNamespace(
+                nodeid="tests/tck/test_conformance.py::test_compare_output_reports_unknown_charset"
+            ),
+        ],
+    )
+
+    pytest_collection_finish(session)
+
+    assert config._tck_selected_identifiers == {selected}


### PR DESCRIPTION
## Summary
- align Python TCK discovery with exact corpus filename patterns and audit adjacent DWL module cases as structural skips
- validate structural policy and require every selected scenario to produce one accounted pytest result
- strengthen comparator and reporting regressions, including XML ordering, unknown charsets, xfail/XPASS accounting, and filtered runs
- ignore the generated Python `.coverage` database

## Testing
- `./gradlew native-lib:pythonTest --rerun-tasks` (86 passed)
- `./gradlew native-lib:stageTckSuites native-lib:pythonTck` (711 passed, 37 skipped, 19 xfailed; 729 selected/accounted, 0 unaccounted)
- `git diff --check`