### PR TITLE
@W-23692110: Skip slow Node TCK intersection case

### DIFF
--- a/native-lib/node/tests/tck/ignore-list.ts
+++ b/native-lib/node/tests/tck/ignore-list.ts
@@ -184,7 +184,6 @@ export const ACCEPTED_BASELINE_MISMATCHES: ExpectedFailurePolicy = {
 };
 
 export const REENABLED_CASES = [
-  "runtime/big_intersection-out.json",
   "runtime/dates_atBeginningOfDay-out.json",
   "runtime/dates_atBeginningOfMonth-out.json",
   "runtime/dates_atBeginningOfWeek-out.json",

--- a/native-lib/node/tests/unit/tck-policy.test.ts
+++ b/native-lib/node/tests/unit/tck-policy.test.ts
@@ -44,9 +44,10 @@ describe("TCK ignore policy", () => {
   });
 
   it("reconciles exclusions into capability skips and strict xfails", () => {
-    expect(Object.keys(CAPABILITY_EXCLUSIONS)).toHaveLength(31);
+    expect(Object.keys(CAPABILITY_EXCLUSIONS)).toHaveLength(32);
     expect(Object.keys(ACCEPTED_BASELINE_MISMATCHES)).toHaveLength(21);
-    expect(REENABLED_CASES).toHaveLength(7);
+    expect(REENABLED_CASES).toHaveLength(6);
+    expect(CAPABILITY_EXCLUSIONS).toHaveProperty("runtime/big_intersection-out.json");
     expect(IGNORED_CASES).toBe(CAPABILITY_EXCLUSIONS);
     expect(validateReconciledPolicy(
       CAPABILITY_EXCLUSIONS,


### PR DESCRIPTION
## Summary
- restore `runtime/big_intersection-out.json` as a Node TCK capability exclusion
- keep the pathological 500-way intersection from exceeding the 30-second Vitest timeout on Linux and Windows CI
- add policy regression coverage so the case cannot be accidentally re-enabled

## Root cause
PR #165 re-enabled this scenario even though it had previously been excluded because it takes about 34 seconds on Windows CI. The post-merge run timed out consistently at 30 seconds on both Linux and Windows, causing the captured Node binding step and final workflow aggregator to fail.

## Validation
- `npm test -- tests/unit/tck-policy.test.ts`
- `npm run build:ts`
- `npm run test:tck` (729 selected, 676 passed, 21 expected failures, 32 skipped, 0 failed, 0 unaccounted)
- `git diff --check`