### PR TITLE
@W-23751548: Remove unused AWS credential configuration

### DIFF
--- a/native-cli/build.gradle
+++ b/native-cli/build.gradle
@@ -40,14 +40,6 @@ dependencies {
     testRuntimeOnly 'com.vladsch.flexmark:flexmark-all:0.62.2'
 }
 
-ext {
-    aws = [
-            accessKey: System.getenv("AWS_ACCESS_KEY_ID"),
-            secretKey: System.getenv("AWS_SECRET_KEY")
-    ]
-}
-
-
 def genDirectory = new File("$project.buildDir/genresource")
 
 


### PR DESCRIPTION
## Summary
- remove the unused `ext.aws` Gradle map from `native-cli/build.gradle`
- eliminate the repository source references to `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY`

## Validation
- `./gradlew native-cli:tasks --all`
- `git diff --check`
- repository search confirms no remaining source or workflow references to either AWS credential environment variable