### PR TITLE
@W-23751548: Fix portable release asset discovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,15 +119,7 @@ jobs:
             mv "$source" "release-assets/dwlib-${VERSION}-${platform}.${extension}"
           done
           gh release view "$TAG" || gh release create "$TAG" --generate-notes
-          mapfile -d '' assets < <(find release-assets -type f \(
-            -name '*.zip' -o
-            -name '*.whl' -o
-            -name '*.tgz' -o
-            -name 'dwlib-*.so' -o
-            -name 'dwlib-*.dll' -o
-            -name 'dwlib-*.dylib' -o
-            -name 'dwlib-*.h'
-          \) -print0)
+          mapfile -d '' assets < <(find release-assets -type f -print0)
           if [ "${#assets[@]}" -eq 0 ]; then
             echo "release artifacts are missing"
             exit 1


### PR DESCRIPTION
## Summary
- remove the unsupported grouped `find` name expression from the release publisher
- retain `-type f` so downloaded artifact directories with archive-like names are not uploaded

## Root cause
The self-hosted release runner rejected the parenthesized `find` expression before it collected any assets:

```text
find: invalid expression; expected to find a `)` but didn't see one
```

## Verification
- Python YAML parsing for `.github/workflows/release.yml`
- shell fixture proving `find -type f` excludes a `.zip` directory while retaining four regular asset files
- `git diff --check`