### PR TITLE
Fix day count in outdated spells warning

### DIFF
--- a/native-cli/src/main/scala/org/mule/weave/dwnative/cli/utils/SpellsUtils.scala
+++ b/native-cli/src/main/scala/org/mule/weave/dwnative/cli/utils/SpellsUtils.scala
@@ -2,13 +2,16 @@ package org.mule.weave.dwnative.cli.utils
 
 import org.mule.weave.dwnative.cli.Console
 import org.mule.weave.dwnative.cli.utils.SpellsUtils.DATA_WEAVE_GRIMOIRE_FOLDER
+import org.mule.weave.dwnative.cli.utils.SpellsUtils.MILLIS_PER_DAY
 import org.mule.weave.dwnative.utils
 
 import java.io.File
 import java.nio.file.Files
+import java.util.concurrent.TimeUnit
 
 object SpellsUtils {
   val DATA_WEAVE_GRIMOIRE_FOLDER = "data-weave-grimoire"
+  private val MILLIS_PER_DAY: Long = TimeUnit.DAYS.toMillis(1)
 }
 
 class SpellsUtils(console: Console) {
@@ -38,7 +41,7 @@ class SpellsUtils(console: Console) {
   def daysSinceLastUpdate(): Int = {
     val lastModified = lastUpdatedMarkFile().lastModified()
     val millis = System.currentTimeMillis() - lastModified
-    (millis / (1000 * 60 * 20 * 24)).asInstanceOf[Int]
+    (millis / MILLIS_PER_DAY).asInstanceOf[Int]
   }
 
   def grimoireFolder(wizard: String): File = {

--- a/native-cli/src/test/scala/org/mule/weave/dwnative/cli/DataWeaveCLITest.scala
+++ b/native-cli/src/test/scala/org/mule/weave/dwnative/cli/DataWeaveCLITest.scala
@@ -11,6 +11,8 @@ import picocli.CommandLine
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
 import scala.io.Source
 
 class DataWeaveCLITest extends AnyFreeSpec with Matchers {
@@ -83,6 +85,44 @@ class DataWeaveCLITest extends AnyFreeSpec with Matchers {
     val source = Source.fromBytes(stream.toByteArray, "UTF-8")
     val result: String = source.mkString
     result.trim shouldBe "\"DW Rules\""
+  }
+
+  "should warn to run `dw spell update` when spells were last updated more than 30 days ago" in {
+    val localSpell: File = TestUtils.getMyLocalSpell
+    val console = new TestConsole(System.in, new ByteArrayOutputStream(), Map(DataWeaveUtils.DW_HOME_VAR -> dwHomeLastUpdatedDaysAgo(31).getAbsolutePath))
+    val dwcli = createCommandLine(console)
+    val exitCode = dwcli.execute("spell", "--local", localSpell.getName, "--spell-home", localSpell.getParentFile.getAbsolutePath)
+    exitCode shouldBe 0
+    console.infoMessages should contain("Your spells are getting old. 31 days since last update. Please run \n dw spell update")
+  }
+
+  "should not warn about old spells when they were last updated less than 30 days ago" in {
+    val localSpell: File = TestUtils.getMyLocalSpell
+    val console = new TestConsole(System.in, new ByteArrayOutputStream(), Map(DataWeaveUtils.DW_HOME_VAR -> dwHomeLastUpdatedDaysAgo(20).getAbsolutePath))
+    val dwcli = createCommandLine(console)
+    val exitCode = dwcli.execute("spell", "--local", localSpell.getName, "--spell-home", localSpell.getParentFile.getAbsolutePath)
+    exitCode shouldBe 0
+    console.infoMessages.filter(_.startsWith("Your spells are getting old")) shouldBe empty
+  }
+
+  "should not warn about old spells when they were last updated exactly 30 days ago" in {
+    val localSpell: File = TestUtils.getMyLocalSpell
+    val console = new TestConsole(System.in, new ByteArrayOutputStream(), Map(DataWeaveUtils.DW_HOME_VAR -> dwHomeLastUpdatedDaysAgo(30).getAbsolutePath))
+    val dwcli = createCommandLine(console)
+    val exitCode = dwcli.execute("spell", "--local", localSpell.getName, "--spell-home", localSpell.getParentFile.getAbsolutePath)
+    exitCode shouldBe 0
+    console.infoMessages.filter(_.startsWith("Your spells are getting old")) shouldBe empty
+  }
+
+  private def dwHomeLastUpdatedDaysAgo(days: Int): File = {
+    val dwHome = Files.createTempDirectory("dw-home").toFile
+    val grimoires = new File(dwHome, "grimoires")
+    grimoires.mkdirs()
+    val lastUpdate = new File(grimoires, "lastUpdate.txt")
+    Files.write(lastUpdate.toPath, "LAST UPDATE".getBytes("UTF-8"))
+    // The extra hour keeps the timestamp well inside the expected day
+    lastUpdate.setLastModified(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days) - TimeUnit.HOURS.toMillis(1)) shouldBe true
+    dwHome
   }
 
 //  "should be able to run a local spell with a dependency" in {


### PR DESCRIPTION
Closes #88

## Summary

#88 reports that the "Your spells are getting old" warning tells users to run `dw update-spells`,
which doesn't exist. That text was already changed to `dw spell update` in #90, but the issue
stayed open. The same warning still reports the wrong number of days, and this PR fixes that.

## Root cause

`SpellsUtils.daysSinceLastUpdate` divides the elapsed time by `1000 * 60 * 20 * 24`, which is
8 hours rather than a day. As a result the warning:

- shows three times the real age, and
- appears after about 10 days instead of the intended 30 (`lastUpdate > 30` in `PicoRunSpell`).

The screenshot in #88 shows this. `lastUpdate.txt` was set to 2023-09-01 and the issue was
opened on 2023-10-10 (about 39 days later), yet the CLI printed "118 days since last update".

## Changes

- `SpellsUtils.daysSinceLastUpdate`: divide by a named `MILLIS_PER_DAY` constant
  (`TimeUnit.DAYS.toMillis(1)`) instead of the hand-written literal that had the typo.
- `DataWeaveCLITest`: three tests that point `DW_HOME` at a temp dir, backdate
  `grimoires/lastUpdate.txt` and run the local test spell:
  - 31 days old: expects `Your spells are getting old. 31 days since last update. Please run \n dw spell update`
    (before this fix it printed 93 days)
  - 20 days old: expects no warning (before this fix it warned with 60 days)
  - exactly 30 days old: expects no warning, which pins the `> 30` boundary

Behavior change for users: the warning now appears after 30 real days instead of about 10, and
shows the real age.

## Testing

```bash
./gradlew native-cli:test --tests "org.mule.weave.dwnative.cli.DataWeaveCLITest"  # new tests fail before the fix, 18/18 pass after
./gradlew native-cli:test                                                          # 19/19 pass
```
